### PR TITLE
Add flex-wrap for Tab Package

### DIFF
--- a/resources/js/components/DefaultField.vue
+++ b/resources/js/components/DefaultField.vue
@@ -59,6 +59,7 @@
                         tabs.item(i).className += " w-full"
                     }
                     this.$parent.$el.parentElement.classList.add('flex')
+                    this.$parent.$el.parentElement.classList.add('flex-wrap')
                 }
             }
 

--- a/resources/js/components/PanelItem.vue
+++ b/resources/js/components/PanelItem.vue
@@ -46,6 +46,7 @@
                         tabs.item(i).className += " w-full"
                     }
                     this.$parent.$el.parentElement.classList.add('flex')
+                    this.$parent.$el.parentElement.classList.add('flex-wrap')
                 }
             }
 


### PR DESCRIPTION
Hello,

im using your package with the tab-package. But the flex-wrap is missing in the tab panel

**without flex**
![Bildschirmfoto 2020-08-12 um 11 16 04](https://user-images.githubusercontent.com/5220826/89998053-52732a00-dc8d-11ea-8fdd-3e6905e2f8dd.jpg)


**with flex**
![Bildschirmfoto 2020-08-12 um 11 16 10](https://user-images.githubusercontent.com/5220826/89998048-50a96680-dc8d-11ea-9c65-ccce4d528caa.jpg)

