### PR TITLE
Remove empty CSS

### DIFF
--- a/src/NovaGridSystem.php
+++ b/src/NovaGridSystem.php
@@ -15,7 +15,6 @@ class NovaGridSystem extends Tool
     public function boot()
     {
         Nova::script('nova-grid-system', __DIR__.'/../dist/js/tool.js');
-        Nova::style('nova-grid-system', __DIR__.'/../dist/css/tool.css');
     }
 
     /**


### PR DESCRIPTION
There is no benefit in loading the stylesheet when it's only referring to an empty file.

![image](https://user-images.githubusercontent.com/12232155/126336183-512e336c-7d04-4d68-8a36-e21bb46eb978.png)

laravel/nova-issues#3474