### PR TITLE
Don't boot Nova Request in the Service Provider

### DIFF
--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -15,198 +15,206 @@ use CodencoDev\NovaGridSystem\Http\Middleware\Authorize;
 
 class ToolServiceProvider extends ServiceProvider
 {
-
-
     /**
      * Bootstrap any application services.
-     *
-     * @return void
      */
-    public function boot(NovaRequest $novaRequest)
+    public function boot(): void
     {
+        $this->publishConfiguration();
+        $this->bootMacros();
+    }
 
+    protected function publishConfiguration(): void
+    {
         $this->publishes([
             __DIR__.'/../config/nova-grid-system.php' => config_path('nova-grid-system.php'),
         ], 'nova-grid-system');
+    }
 
+    protected function bootMacros(): void
+    {
+        $request = fn () => resolve(NovaRequest::class);
 
-        Nova::serving(function (ServingNova $event) use ($novaRequest) {
+        $this->bootHelperMacros();
+        $this->bootGlobalMacros();
+        $this->bootCreatingMacros();
+        $this->bootUpdatingMacros();
+        $this->bootFormMacros();
+        $this->bootDetailMacros();
+    }
 
-            /**
-             * HELPERS MACROS
-             */
-            NovaRequest::macro('getRequestType', function () {
-                $requestType = '';
-                if ($this->isCreateOrAttachRequest()) {
-                    $requestType = 'creating';
-                } elseif ($this->isUpdateOrUpdateAttachedRequest()) {
-                    $requestType = 'updating';
-                } else {
-                    $requestType = 'detail';
-                }
-                return $requestType;
-            });
-            NovaRequest::macro('isActivate', function (string $meta,string $context, bool $scope = false) {
-                $requestType = $this->getRequestType();
-
-                return
-                    ($context == 'all'
-                        || ($context=='forms' ? collect(['creating','updating'])->contains($requestType) : $requestType == $context)
-                    )
-                    && config('nova-grid-system.nova_grid_system_enabled', true)
-                    && config('nova-grid-system.'.$requestType.'.'.$meta, true)
-                    && ($scope ? $this->isActivateGlobally($meta) : true);
-            });
-
-            NovaRequest::macro('isActivateGlobally', function (string $meta) {
-                $requestType = $this->getRequestType();
-                return config('nova-grid-system.'.$meta.'_scope.'.$requestType, true);
-            });
-
-            Field::macro('withSize', function (string $size = 'w-full') use ($novaRequest) {
-
-                if ($novaRequest->isActivateGlobally('stacked')) {
-                    $this->stacked();
-                }
-
-                return $this->withMeta(['size' => $size]);
-            });
-
-
-            /**
-             * GLOBALS MACROS
-             */
-
-            Field::macro('size', function ($size = 'w-full') use ($novaRequest) {
-
-                if ($novaRequest->isActivate('size','all', $scope = true)) {
-                    $this->withSize($size);
-                }
-                return $this;
-            });
-
-            Field::macro('removeBottomBorder', function ($remove = true) use ($novaRequest) {
-                if ($novaRequest->isActivate('remove_bottom_border','all', $scope = true)) {
-                    $this->withMeta(['removeBottomBorder' => $remove]);
-                }
-                return $this;
-            });
-
-            /**
-             * CREATING
-             */
-            Field::macro('sizeOnCreating', function ($size = 'w-full') use ($novaRequest) {
-                if ($novaRequest->isActivate('size','creating')) {
-                    if (
-                        config('nova-grid-system.stacked_auto', true)
-                        && config('nova-grid-system.creating.stacked', true)
-                    ) {
-                        $this->stacked();
-                    }
-                    $this->withMeta(['size' => $size]);
-                }
-                return $this;
-            });
-
-            Field::macro('stackedOnCreating', function ($stacked = true) use ($novaRequest) {
-                if ($novaRequest->isActivate('stacked','creating')) {
-                    $this->stacked($stacked);
-                }
-                return $this;
-            });
-
-            Field::macro('removeBottomBorderOnCreating', function ($remove = true) use ($novaRequest) {
-                if ($novaRequest->isActivate('remove_bottom_border','creating')) {
-                    $this->withMeta(['removeBottomBorder' => $remove]);
-                }
-                return $this;
-            });
-
-
-            /**
-             * UPDATING
-             */
-            Field::macro('sizeOnUpdating', function ($size = 'w-full') use ($novaRequest) {
-                if ($novaRequest->isActivate('size','updating')) {
-                    $this->withSize($size);
-                }
-                return $this;
-            });
-
-            Field::macro('stackedOnUpdating', function ($stacked = true) use ($novaRequest) {
-                if ($novaRequest->isActivate('stacked','updating')) {
-                    $this->stacked($stacked);
-                }
-                return $this;
-            });
-
-            Field::macro('removeBottomBorderOnUpdating', function ($remove = true) use ($novaRequest) {
-                if ($novaRequest->isActivate('remove_bottom_border','updating')) {
-                    $this->withMeta(['removeBottomBorder' => $remove]);
-                }
-                return $this;
-            });
-
-            /**
-             * FORMS
-             */
-            Field::macro('sizeOnForms', function ($size = 'w-full') use ($novaRequest) {
-                if ($novaRequest->isActivate('size','forms')) {
-                    $this->withSize($size);
-                }
-                return $this;
-            });
-
-            Field::macro('stackedOnForms', function ($stacked = true) use ($novaRequest) {
-                if ($novaRequest->isActivate('stacked','forms')) {
-                    $this->stacked($stacked);
-                }
-                return $this;
-            });
-
-            Field::macro('removeBottomBorderOnForms', function ($remove = true) use ($novaRequest) {
-                if ($novaRequest->isActivate('remove_bottom_border','forms')) {
-                    $this->withMeta(['removeBottomBorder' => $remove]);
-                }
-                return $this;
-            });
-
-            /**
-             * DETAIL
-             */
-            Field::macro('sizeOnDetail', function ($size = 'w-full') use ($novaRequest) {
-                if ($novaRequest->isActivate('size','detail')) {
-                    $this->withSize($size);
-                }
-                return $this;
-            });
-
-            Field::macro('stackedOnDetail', function ($stacked = true) use ($novaRequest) {
-                if ($novaRequest->isActivate('stacked','detail')) {
-                    $this->stacked($stacked);
-                }
-                return $this;
-            });
-
-            Field::macro('removeBottomBorderOnDetail', function ($remove = true) use ($novaRequest) {
-                if ($novaRequest->isActivate('remove_bottom_border','detail')) {
-                    $this->withMeta(['removeBottomBorder' => $remove]);
-                }
-                return $this;
-            });
+    protected function bootHelperMacros(): void
+    {
+        NovaRequest::macro('getRequestType', function () {
+            $requestType = '';
+            if ($this->isCreateOrAttachRequest()) {
+                $requestType = 'creating';
+            } elseif ($this->isUpdateOrUpdateAttachedRequest()) {
+                $requestType = 'updating';
+            } else {
+                $requestType = 'detail';
+            }
+            return $requestType;
         });
 
+        NovaRequest::macro('isActivate', function (string $meta, string $context, bool $scope = false) {
+            $requestType = $this->getRequestType();
+
+            return
+                ($context == 'all'
+                    || ($context=='forms' ? collect(['creating','updating'])->contains($requestType) : $requestType == $context)
+                )
+                && config('nova-grid-system.nova_grid_system_enabled', true)
+                && config('nova-grid-system.'.$requestType.'.'.$meta, true)
+                && ($scope ? $this->isActivateGlobally($meta) : true);
+        });
+
+        NovaRequest::macro('isActivateGlobally', function (string $meta) {
+            $requestType = $this->getRequestType();
+            return config('nova-grid-system.'.$meta.'_scope.'.$requestType, true);
+        });
+
+        Field::macro('isRequestActivate', function (string $meta, string $context, bool $scope = false) {
+            return resolve(NovaRequest::class)->isActivate($meta, $context, $scope);
+        });
+
+        Field::macro('isRequestActivateGlobally', function (string $meta {
+            return resolve(NovaRequest::class)->isActivate($meta);
+        });
+
+        Field::macro('withSize', function (string $size = 'w-full') {
+            if ($this->isRequestActivateGlobally('stacked')) {
+                $this->stacked();
+            }
+
+            return $this->withMeta(['size' => $size]);
+        });
+    }
+
+    protected function bootGlobalMacros(): void
+    {
+        Field::macro('size', function ($size = 'w-full') {
+            if ($this->isRequestActivate('size','all', $scope = true)) {
+                $this->withSize($size);
+            }
+            return $this;
+        });
+
+        Field::macro('removeBottomBorder', function ($remove = true) {
+            if ($this->isRequestActivate('remove_bottom_border','all', $scope = true)) {
+                $this->withMeta(['removeBottomBorder' => $remove]);
+            }
+            return $this;
+        });
+    }
+
+    protected function bootCreatingMacros(): void
+    {
+        Field::macro('sizeOnCreating', function ($size = 'w-full') {
+            if ($this->isRequestActivate('size','creating')) {
+                if (
+                    config('nova-grid-system.stacked_auto', true)
+                    && config('nova-grid-system.creating.stacked', true)
+                ) {
+                    $this->stacked();
+                }
+                $this->withMeta(['size' => $size]);
+            }
+            return $this;
+        });
+
+        Field::macro('stackedOnCreating', function ($stacked = true) {
+            if ($this->isRequestActivate('stacked','creating')) {
+                $this->stacked($stacked);
+            }
+            return $this;
+        });
+
+        Field::macro('removeBottomBorderOnCreating', function ($remove = true) {
+            if ($this->isRequestActivate('remove_bottom_border','creating')) {
+                $this->withMeta(['removeBottomBorder' => $remove]);
+            }
+            return $this;
+        });
+    }
+
+    protected function bootUpdatingMacros(): void
+    {
+        Field::macro('sizeOnUpdating', function ($size = 'w-full') {
+            if ($this->isRequestActivate('size','updating')) {
+                $this->withSize($size);
+            }
+            return $this;
+        });
+
+        Field::macro('stackedOnUpdating', function ($stacked = true) {
+            if ($this->isRequestActivate('stacked','updating')) {
+                $this->stacked($stacked);
+            }
+            return $this;
+        });
+
+        Field::macro('removeBottomBorderOnUpdating', function ($remove = true) {
+            if ($this->isRequestActivate('remove_bottom_border','updating')) {
+                $this->withMeta(['removeBottomBorder' => $remove]);
+            }
+            return $this;
+        });
+    }
+
+    protected function bootFormMacros(): void
+    {
+        Field::macro('sizeOnForms', function ($size = 'w-full') {
+            if ($this->isRequestActivate('size','forms')) {
+                $this->withSize($size);
+            }
+            return $this;
+        });
+
+        Field::macro('stackedOnForms', function ($stacked = true) {
+            if ($this->isRequestActivate('stacked','forms')) {
+                $this->stacked($stacked);
+            }
+            return $this;
+        });
+
+        Field::macro('removeBottomBorderOnForms', function ($remove = true) {
+            if ($this->isRequestActivate('remove_bottom_border','forms')) {
+                $this->withMeta(['removeBottomBorder' => $remove]);
+            }
+            return $this;
+        });
+    }
+
+    protected function bootDetailMacros(): void
+    {
+        Field::macro('sizeOnDetail', function ($size = 'w-full') {
+            if ($this->isRequestActivate('size','detail')) {
+                $this->withSize($size);
+            }
+            return $this;
+        });
+
+        Field::macro('stackedOnDetail', function ($stacked = true) {
+            if ($this->isRequestActivate('stacked','detail')) {
+                $this->stacked($stacked);
+            }
+            return $this;
+        });
+
+        Field::macro('removeBottomBorderOnDetail', function ($remove = true) {
+            if ($this->isRequestActivate('remove_bottom_border','detail')) {
+                $this->withMeta(['removeBottomBorder' => $remove]);
+            }
+            return $this;
+        });
     }
 
     /**
      * Register any application services.
-     *
-     * @return void
      */
-    public function register()
+    public function register(): void
     {
         //
     }
-
-
 }

--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -17,21 +17,23 @@ class ToolServiceProvider extends ServiceProvider
 {
     /**
      * Bootstrap any application services.
+     *
+     * @return void
      */
-    public function boot(): void
+    public function boot()
     {
         $this->publishConfiguration();
         $this->bootMacros();
     }
 
-    protected function publishConfiguration(): void
+    protected function publishConfiguration()
     {
         $this->publishes([
             __DIR__.'/../config/nova-grid-system.php' => config_path('nova-grid-system.php'),
         ], 'nova-grid-system');
     }
 
-    protected function bootMacros(): void
+    protected function bootMacros()
     {
         $request = fn () => resolve(NovaRequest::class);
 
@@ -43,7 +45,7 @@ class ToolServiceProvider extends ServiceProvider
         $this->bootDetailMacros();
     }
 
-    protected function bootHelperMacros(): void
+    protected function bootHelperMacros()
     {
         NovaRequest::macro('getRequestType', function () {
             $requestType = '';
@@ -91,7 +93,7 @@ class ToolServiceProvider extends ServiceProvider
         });
     }
 
-    protected function bootGlobalMacros(): void
+    protected function bootGlobalMacros()
     {
         Field::macro('size', function ($size = 'w-full') {
             if ($this->isRequestActivate('size','all', $scope = true)) {
@@ -108,7 +110,7 @@ class ToolServiceProvider extends ServiceProvider
         });
     }
 
-    protected function bootCreatingMacros(): void
+    protected function bootCreatingMacros()
     {
         Field::macro('sizeOnCreating', function ($size = 'w-full') {
             if ($this->isRequestActivate('size','creating')) {
@@ -138,7 +140,7 @@ class ToolServiceProvider extends ServiceProvider
         });
     }
 
-    protected function bootUpdatingMacros(): void
+    protected function bootUpdatingMacros()
     {
         Field::macro('sizeOnUpdating', function ($size = 'w-full') {
             if ($this->isRequestActivate('size','updating')) {
@@ -162,7 +164,7 @@ class ToolServiceProvider extends ServiceProvider
         });
     }
 
-    protected function bootFormMacros(): void
+    protected function bootFormMacros()
     {
         Field::macro('sizeOnForms', function ($size = 'w-full') {
             if ($this->isRequestActivate('size','forms')) {
@@ -186,7 +188,7 @@ class ToolServiceProvider extends ServiceProvider
         });
     }
 
-    protected function bootDetailMacros(): void
+    protected function bootDetailMacros()
     {
         Field::macro('sizeOnDetail', function ($size = 'w-full') {
             if ($this->isRequestActivate('size','detail')) {
@@ -212,8 +214,10 @@ class ToolServiceProvider extends ServiceProvider
 
     /**
      * Register any application services.
+     *
+     * @return void
      */
-    public function register(): void
+    public function register()
     {
         //
     }


### PR DESCRIPTION
After installing this package, I ran into an issue that was a bit tricky to source, but it ultimately comes back here.

In short, the service provider for this package injects `NovaRequest` as a dependency to the service provider's boot method. Booting a form request early in the lifecycle of a Laravel application causes unintended side-effects.

This PR simply changes the service provider to inject the `NovaRequest` instance as its needed, which is inside of macros exclusively. In other words, until one of these macros is called, the `NovaRequest` instance isn't resolved out of the container. This prevents said side-effects.

Additionally, macros are loaded statically, so you don't need to register them on the `ServingNova` event; you can just register them.